### PR TITLE
Some jdenticon fixes

### DIFF
--- a/QtIdenticon.pro
+++ b/QtIdenticon.pro
@@ -13,7 +13,7 @@ DESTDIR  = plugins
 # feature of Qt which has been marked as deprecated (the exact warnings
 # depend on your compiler). Please consult the documentation of the
 # deprecated API in order to know how to port your code away from it.
-DEFINES += QT_DEPRECATED_WARNINGS
+DEFINES += QT_DEPRECATED_WARNINGS QT_NO_DEBUG_OUTPUT
 
 # You can also make your code fail to compile if you use deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/QtIdenticon.pro
+++ b/QtIdenticon.pro
@@ -13,7 +13,11 @@ DESTDIR  = plugins
 # feature of Qt which has been marked as deprecated (the exact warnings
 # depend on your compiler). Please consult the documentation of the
 # deprecated API in order to know how to port your code away from it.
-DEFINES += QT_DEPRECATED_WARNINGS QT_NO_DEBUG_OUTPUT
+DEFINES += QT_DEPRECATED_WARNINGS
+
+CONFIG(debug) {
+    DEFINES += QT_NO_DEBUG_OUTPUT
+}
 
 # You can also make your code fail to compile if you use deprecated APIs.
 # In order to do so, uncomment the following line.

--- a/src/rendering/svgpath.h
+++ b/src/rendering/svgpath.h
@@ -3,6 +3,7 @@
 
 #include <QList>
 #include <QString>
+#include <QPointF>
 
 namespace rendering {
 


### PR DESCRIPTION
This brings jdenticon caching, removes debug output by default (should there be configuration for this?﻿), and adds a header so that it compiles on Qt 5.15 and greater.
