### PR TITLE
Add option to supply input to cli tool

### DIFF
--- a/src/qtidenticon.cpp
+++ b/src/qtidenticon.cpp
@@ -13,8 +13,9 @@ main(int argc, char *argv[])
 {
     QCoreApplication app(argc, argv);
     QCommandLineParser parser;
-    parser.setApplicationDescription("Generates SVGs from strings. For each input, the output is:\n"
-                                     "input<newline>SVG<newline>");
+    parser.setApplicationDescription(
+      "Generates SVGs from strings (supplied via command line arguments or taken from stdin). For "
+      "each input, the output is:\ninput<newline>SVG<newline>");
     parser.addHelpOption();
     parser.addOption(
       {{"i", "input"}, "Input to feed the generator, can appear multiple times.", "string"});

--- a/src/qtidenticon.cpp
+++ b/src/qtidenticon.cpp
@@ -1,20 +1,40 @@
+#include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QtDebug>
 #include <QtGlobal>
+
+#include <iostream>
+#include <string>
 
 #include "identicon.h"
 
 int
 main(int argc, char *argv[])
 {
-    QCoreApplication a(argc, argv);
-    QList<QString> hashes = {
-      "@red_sky:ocean.joedonofry.com",
-    };
-    for (const QString &hash : qAsConst(hashes)) {
-        QByteArray hashArr = QByteArray::fromStdString(hash.toStdString());
-        qInfo() << hash;
-        qInfo() << Identicon::generateSvg(hash, 256, false);
+    QCoreApplication app(argc, argv);
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Generates SVGs from strings. For each input, the output is:\n"
+                                     "input<newline>SVG<newline>");
+    parser.addHelpOption();
+    parser.addOption(
+      {{"i", "input"}, "Input to feed the generator, can appear multiple times.", "string"});
+    parser.process(app);
+
+    QList<QString> inputList = parser.values("input");
+    // get strings from stdin if nothing is supplied via command line
+    if (inputList.empty()) {
+        std::string line;
+        while (!std::cin.eof()) {
+            std::getline(std::cin, line);
+            if (!line.empty()) {
+                inputList.append(QString::fromStdString(line));
+            }
+        }
+    }
+
+    for (const auto &input : inputList) {
+        std::cout << input.toStdString() << '\n';
+        std::cout << Identicon::generateSvg(input, 256, false).toStdString() << '\n';
     }
     return 0;
     // return a.exec();


### PR DESCRIPTION
If -i / --input is used, get input strings from that. Otherwise get
input strings from stdin.

I didn't figure out qmake, so it has to be compiled with `g++ -lqtjdenticon src/qtidenticon.cpp -L. $(pkg-config --libs --cflags Qt5Gui) -fPIC -o qt-jdenticon` and run with `LD_LIBRARY_PATH="$(realpath .)" ./qt-jdenticon` for now.