### PR TITLE
Switch from QHash to QMap to ensure SVG path order between runs

### DIFF
--- a/src/rendering/svgrenderer.h
+++ b/src/rendering/svgrenderer.h
@@ -2,7 +2,7 @@
 #define SVGRENDERER_H
 
 #include <QColor>
-#include <QHash>
+#include <QMap>
 #include <QPointF>
 #include <QString>
 #include <QTextStream>
@@ -16,7 +16,7 @@ namespace rendering {
 class SvgRenderer : public Renderer
 {
 private:
-    QHash<QString, SvgPath *> pathsByColor_;
+    QMap<QString, SvgPath *> pathsByColor_;
     SvgPath *path_;
     int width_, height_;
     QColor backColor_;


### PR DESCRIPTION
Fixes an issue where SVG Path ordering was different between runs (as the QHash was seeded differently on each startup).  While the SVGs *looked* the same before, they should now actually be byte-for-byte identical in the output.